### PR TITLE
NP-2376 millicores conversion factor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -211,12 +211,12 @@
   version = "v0.0.15"
 
 [[projects]]
-  digest = "1:1b476efeb55b40e900fe5392f259a27906c0b80606375e294023b9969112e5e3"
+  digest = "1:4175c6425c9d71417a68c5036608e89c244d2f4c92010b6c2b34f4800818bd2d"
   name = "github.com/nalej/grpc-infrastructure-go"
   packages = ["."]
   pruneopts = ""
-  revision = "f531d00353efc5e3ca00391c7f404e454e3b42cd"
-  version = "v0.0.48"
+  revision = "843be831319ae6b69bd461da970fae32b79e03f9"
+  version = "v0.0.49"
 
 [[projects]]
   digest = "1:aeb91acd141cc311933fd8e8551090835787dbad6075aa902023dd3d2861b1ca"
@@ -299,12 +299,12 @@
   version = "v0.0.8"
 
 [[projects]]
-  digest = "1:6f3d58f2442978a7843a38e19c226f196d4fe55e06ebdd420b180ca6d57548cf"
+  digest = "1:f69764982c08d7d4d8dbe43ad13ca42498cd1e3956b2f6852c7b80109b7a133f"
   name = "github.com/nalej/grpc-public-api-go"
   packages = ["."]
   pruneopts = ""
-  revision = "6c8de34d9ab5ed09aa0989c949d8768afe5fda62"
-  version = "v0.0.120"
+  revision = "652c757d66341bc24c43be15ba6b9db96cebb1a2"
+  version = "v0.0.123"
 
 [[projects]]
   digest = "1:c98cb0eedf841e8403a81e4d504a2f5f039e3c79b0e77595e87a9319acff2f44"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -123,12 +123,12 @@
   version = "v0.0.89"
 
 [[projects]]
-  digest = "1:ac5518d7f423344804483a40b088ac9484a893781d7ba256abd3f230a9a18190"
+  digest = "1:87c0e694b06b0e75022b13a024fb8e201c7957246e65e3d611909fdb52c148b6"
   name = "github.com/nalej/grpc-application-manager-go"
   packages = ["."]
   pruneopts = ""
-  revision = "742ab37d567f1304428a4352d5735392c8a520de"
-  version = "v0.0.45"
+  revision = "b6395a8c2bac3a8b49d8d194cf90d745e340b0a1"
+  version = "v0.0.47"
 
 [[projects]]
   digest = "1:14935510a150a010a7cb713d816fe04abc36fca1130778c36d1f0be7b15cc9e0"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -211,12 +211,12 @@
   version = "v0.0.15"
 
 [[projects]]
-  digest = "1:1b476efeb55b40e900fe5392f259a27906c0b80606375e294023b9969112e5e3"
+  digest = "1:4175c6425c9d71417a68c5036608e89c244d2f4c92010b6c2b34f4800818bd2d"
   name = "github.com/nalej/grpc-infrastructure-go"
   packages = ["."]
   pruneopts = ""
-  revision = "f531d00353efc5e3ca00391c7f404e454e3b42cd"
-  version = "v0.0.48"
+  revision = "843be831319ae6b69bd461da970fae32b79e03f9"
+  version = "v0.0.49"
 
 [[projects]]
   digest = "1:aeb91acd141cc311933fd8e8551090835787dbad6075aa902023dd3d2861b1ca"
@@ -299,12 +299,12 @@
   version = "v0.0.8"
 
 [[projects]]
-  digest = "1:c5bcaed7a3bc222665f89212ed50b18b8610afbec05f737a72e702c78e83e584"
+  digest = "1:f69764982c08d7d4d8dbe43ad13ca42498cd1e3956b2f6852c7b80109b7a133f"
   name = "github.com/nalej/grpc-public-api-go"
   packages = ["."]
   pruneopts = ""
-  revision = "3cf8b5fefb798bfe00b4e535b29745ea4292953a"
-  version = "v0.0.122"
+  revision = "652c757d66341bc24c43be15ba6b9db96cebb1a2"
+  version = "v0.0.123"
 
 [[projects]]
   digest = "1:c98cb0eedf841e8403a81e4d504a2f5f039e3c79b0e77595e87a9319acff2f44"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-application-manager-go"
-    version="=v0.0.45"
+    version="=v0.0.47"
 
 [[constraint]]
     name="github.com/nalej/grpc-application-network-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,7 +40,7 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-infrastructure-go"
-    version="=v0.0.48"
+    version="=v0.0.49"
 
 [[constraint]]
     name="github.com/nalej/grpc-infrastructure-manager-go"
@@ -88,7 +88,7 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-public-api-go"
-    version="=v0.0.120"
+    version="=v0.0.123"
 
 [[constraint]]
     name="github.com/nalej/grpc-login-api-go"

--- a/cmd/public-api-cli/commands/clusters.go
+++ b/cmd/public-api-cli/commands/clusters.go
@@ -54,6 +54,9 @@ func init() {
 	listClustersCmd.Flags().BoolVarP(&watch, "watch", "w", false, "Watch for changes")
 	clustersCmd.AddCommand(listClustersCmd)
 
+	updateClusterCmd.Flags().Float64Var(&millicoresConversionFactor, "millicoresConversionFactor", -1.0, "Modify the millicoresConversionFactor assigned to the cluster")
+	clustersCmd.AddCommand(updateClusterCmd)
+
 	clusterLabelsCmd.PersistentFlags().StringVar(&clusterID, "clusterID", "", "Cluster identifier")
 	clusterLabelsCmd.PersistentFlags().StringVar(&rawLabels, "labels", "", "Labels separated by ; as in key1:value;key2:value")
 
@@ -183,6 +186,22 @@ func stringToClusterType(ct string) grpc_infrastructure_go.ClusterType {
 	}
 
 	return result
+}
+
+var updateClusterCmd = &cobra.Command{
+	Use:   "update [clusterID]",
+	Short: "Update cluster params",
+	Long:  `Update cluster params`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		SetupLogging()
+		c := cli.NewClusters(
+			cliOptions.Resolve("nalejAddress", nalejAddress),
+			cliOptions.ResolveAsInt("port", nalejPort),
+			insecure, useTLS,
+			cliOptions.Resolve("cacert", caCertPath), cliOptions.Resolve("output", output), cliOptions.ResolveAsInt("labelLength", labelLength))
+		c.Update(cliOptions.Resolve("organizationID", organizationID), args[0], "", millicoresConversionFactor)
+	},
 }
 
 var clusterLabelsCmd = &cobra.Command{

--- a/cmd/public-api-cli/commands/clusters.go
+++ b/cmd/public-api-cli/commands/clusters.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nalej/public-api/internal/app/cli"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"math"
 	"strconv"
 )
 
@@ -54,7 +55,7 @@ func init() {
 	listClustersCmd.Flags().BoolVarP(&watch, "watch", "w", false, "Watch for changes")
 	clustersCmd.AddCommand(listClustersCmd)
 
-	updateClusterCmd.Flags().Float64Var(&millicoresConversionFactor, "millicoresConversionFactor", -1.0, "Modify the millicoresConversionFactor assigned to the cluster")
+	updateClusterCmd.Flags().Float64Var(&millicoresConversionFactor, "millicoresConversionFactor", math.NaN(), "Modify the millicoresConversionFactor assigned to the cluster")
 	clustersCmd.AddCommand(updateClusterCmd)
 
 	clusterLabelsCmd.PersistentFlags().StringVar(&clusterID, "clusterID", "", "Cluster identifier")

--- a/cmd/public-api-cli/commands/variables.go
+++ b/cmd/public-api-cli/commands/variables.go
@@ -78,6 +78,9 @@ var clusterStatFields string
 
 var watch bool
 
+// cluster update
+var millicoresConversionFactor float64
+
 var outputPath string
 var edgeControllerID string
 var assetID string

--- a/internal/app/cli/clusters.go
+++ b/internal/app/cli/clusters.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"reflect"
 	"time"
 
@@ -209,7 +210,7 @@ func (c *Clusters) Update(organizationID string, clusterID string, newName strin
 		ClusterId:                        clusterID,
 		UpdateName:                       true,
 		Name:                             newName,
-		UpdateMillicoresConversionFactor: millicoresConversionFactor > 0,
+		UpdateMillicoresConversionFactor: !math.IsNaN(millicoresConversionFactor),
 		MillicoresConversionFactor:       millicoresConversionFactor,
 	}
 	success, err := client.Update(ctx, updateRequest)

--- a/internal/app/cli/clusters.go
+++ b/internal/app/cli/clusters.go
@@ -208,7 +208,7 @@ func (c *Clusters) Update(organizationID string, clusterID string, newName strin
 	updateRequest := &grpc_public_api_go.UpdateClusterRequest{
 		OrganizationId:                   organizationID,
 		ClusterId:                        clusterID,
-		UpdateName:                       true,
+		UpdateName:                       newName != "",
 		Name:                             newName,
 		UpdateMillicoresConversionFactor: !math.IsNaN(millicoresConversionFactor),
 		MillicoresConversionFactor:       millicoresConversionFactor,

--- a/internal/app/cli/clusters.go
+++ b/internal/app/cli/clusters.go
@@ -191,7 +191,7 @@ func (c *Clusters) ModifyClusterLabels(organizationID string, clusterID string, 
 	c.PrintResultOrError(updated, err, "cannot update cluster labels")
 }
 
-func (c *Clusters) Update(organizationID string, clusterID string, newName string) {
+func (c *Clusters) Update(organizationID string, clusterID string, newName string, millicoresConversionFactor float64) {
 	if organizationID == "" {
 		log.Fatal().Msg("organizationID cannot be empty")
 	}
@@ -205,10 +205,12 @@ func (c *Clusters) Update(organizationID string, clusterID string, newName strin
 	defer conn.Close()
 	defer cancel()
 	updateRequest := &grpc_public_api_go.UpdateClusterRequest{
-		OrganizationId: organizationID,
-		ClusterId:      clusterID,
-		UpdateName:     true,
-		Name:           newName,
+		OrganizationId:                   organizationID,
+		ClusterId:                        clusterID,
+		UpdateName:                       true,
+		Name:                             newName,
+		UpdateMillicoresConversionFactor: millicoresConversionFactor > 0,
+		MillicoresConversionFactor:       millicoresConversionFactor,
 	}
 	success, err := client.Update(ctx, updateRequest)
 	c.PrintResultOrError(success, err, "cannot update cluster information")

--- a/internal/app/cli/table.go
+++ b/internal/app/cli/table.go
@@ -249,7 +249,7 @@ func FromCluster(result *grpc_public_api_go.Cluster, labelLength int) *ResultTab
 		seen = time.Unix(result.LastAliveTimestamp, 0).String()
 	}
 	r = append(r, []string{result.Name, result.ClusterId, result.State.String(), result.Status.String(), seen})
-	r = append(r, []string{"NODES", "LABELS", "MILLICORES CONVERSION FACTOR"})
+	r = append(r, []string{"NODES", "LABELS", "MCF"})
 	r = append(r, []string{fmt.Sprintf("%d", result.TotalNodes), TransformLabels(result.Labels, labelLength), fmt.Sprintf("%g", result.MillicoresConversionFactor)})
 	return &ResultTable{r}
 }

--- a/internal/app/cli/table.go
+++ b/internal/app/cli/table.go
@@ -249,8 +249,8 @@ func FromCluster(result *grpc_public_api_go.Cluster, labelLength int) *ResultTab
 		seen = time.Unix(result.LastAliveTimestamp, 0).String()
 	}
 	r = append(r, []string{result.Name, result.ClusterId, result.State.String(), result.Status.String(), seen})
-	r = append(r, []string{"NODES", "LABELS"})
-	r = append(r, []string{fmt.Sprintf("%d", result.TotalNodes), TransformLabels(result.Labels, labelLength)})
+	r = append(r, []string{"NODES", "LABELS", "MILLICORES CONVERSION FACTOR"})
+	r = append(r, []string{fmt.Sprintf("%d", result.TotalNodes), TransformLabels(result.Labels, labelLength), fmt.Sprintf("%g", result.MillicoresConversionFactor)})
 	return &ResultTable{r}
 }
 

--- a/internal/pkg/entities/conversions.go
+++ b/internal/pkg/entities/conversions.go
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package entities
@@ -33,13 +32,15 @@ import (
 func ToInfraClusterUpdate(update grpc_public_api_go.UpdateClusterRequest) *grpc_infrastructure_go.UpdateClusterRequest {
 
 	result := &grpc_infrastructure_go.UpdateClusterRequest{
-		OrganizationId: update.OrganizationId,
-		ClusterId:      update.ClusterId,
-		UpdateName:     update.Name != "",
-		Name:           update.Name,
-		AddLabels:      update.AddLabels,
-		RemoveLabels:   update.RemoveLabels,
-		Labels:         update.Labels,
+		OrganizationId:                   update.OrganizationId,
+		ClusterId:                        update.ClusterId,
+		UpdateName:                       update.Name != "",
+		Name:                             update.Name,
+		AddLabels:                        update.AddLabels,
+		RemoveLabels:                     update.RemoveLabels,
+		Labels:                           update.Labels,
+		UpdateMillicoresConversionFactor: update.UpdateMillicoresConversionFactor,
+		MillicoresConversionFactor:       update.MillicoresConversionFactor,
 	}
 
 	return result
@@ -47,19 +48,20 @@ func ToInfraClusterUpdate(update grpc_public_api_go.UpdateClusterRequest) *grpc_
 
 func ToPublicAPICluster(source *grpc_infrastructure_go.Cluster, totalNodes int64, runningNodes int64) *grpc_public_api_go.Cluster {
 	return &grpc_public_api_go.Cluster{
-		OrganizationId:     source.OrganizationId,
-		ClusterId:          source.ClusterId,
-		Name:               source.Name,
-		ClusterTypeName:    source.ClusterType.String(),
-		MultitenantSupport: source.Multitenant.String(),
-		StatusName:         source.ClusterStatus.String(),
-		Status:             source.ClusterStatus,
-		Labels:             source.Labels,
-		TotalNodes:         totalNodes,
-		RunningNodes:       runningNodes,
-		LastAliveTimestamp: source.LastAliveTimestamp,
-		State:              source.State,
-		StateName:          source.State.String(),
+		OrganizationId:             source.OrganizationId,
+		ClusterId:                  source.ClusterId,
+		Name:                       source.Name,
+		ClusterTypeName:            source.ClusterType.String(),
+		MultitenantSupport:         source.Multitenant.String(),
+		StatusName:                 source.ClusterStatus.String(),
+		Status:                     source.ClusterStatus,
+		Labels:                     source.Labels,
+		TotalNodes:                 totalNodes,
+		RunningNodes:               runningNodes,
+		LastAliveTimestamp:         source.LastAliveTimestamp,
+		MillicoresConversionFactor: source.MillicoresConversionFactor,
+		State:                      source.State,
+		StateName:                  source.State.String(),
 	}
 }
 

--- a/internal/pkg/server/unified-logging/handler.go
+++ b/internal/pkg/server/unified-logging/handler.go
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package unified_logging
@@ -20,6 +19,7 @@ package unified_logging
 import (
 	"context"
 	"github.com/nalej/derrors"
+	"github.com/nalej/grpc-application-manager-go"
 	"github.com/nalej/grpc-public-api-go"
 	"github.com/nalej/grpc-utils/pkg/conversions"
 	"github.com/nalej/public-api/internal/pkg/authhelper"
@@ -50,4 +50,9 @@ func (h *Handler) Search(ctx context.Context, request *grpc_public_api_go.Search
 		return nil, conversions.ToGRPCError(err)
 	}
 	return h.Manager.Search(request)
+}
+
+func (h *Handler) Catalog(ctx context.Context, request *grpc_application_manager_go.AvailableLogRequest) (*grpc_application_manager_go.AvailableLogResponse, error) {
+	// TODO not implemented yet
+	return nil, derrors.NewUnimplementedError("Not implemented yet")
 }


### PR DESCRIPTION
#### What does this PR do?

- Enable the `cluster update` command.
- Include the `millicoresConversionFactor` flag to the `update` command.
- Update the output when printing a Cluster on the CLI.

#### How should this be manually tested?

- Upgrade `system-model`, `infrastructure-manager` to the `staging` version.
- Ensure that the `nalej.clusters` table have the column `millicores_conversion_factor`.
- Upgrade `public-api`

' ./public-api-cli cluster update [clusterID] --millicoresConversionFactor 1.2`

#### Any background context you want to provide?
It has been decided that millicoresConversionFactor can take any float number, negatives included.

#### What are the relevant tickets?

- [NP-2376](https://nalej.atlassian.net/browse/NP-2376)
- [NP-2368](https://nalej.atlassian.net/browse/NP-2368)

#### What I have learnt
math.NaN() != math.NaN() is true