### PR TITLE
NP-2401 Improve cluster continuous listing

### DIFF
--- a/cmd/public-api-cli/commands/clusters.go
+++ b/cmd/public-api-cli/commands/clusters.go
@@ -93,7 +93,7 @@ func init() {
 	scaleClusterCmd.PersistentFlags().StringVar(&provisionTargetPlatform, "targetPlatform", "", "Target platform")
 	clustersCmd.AddCommand(scaleClusterCmd)
 
-	uninstallClusterCmd.Flags().StringVar(&provisionTargetPlatform, "targetPlatform", "", "Target platform")
+	uninstallClusterCmd.Flags().StringVar(&provisionTargetPlatform, "targetPlatform", "AZURE", "Target platform")
 	clustersCmd.AddCommand(uninstallClusterCmd)
 
 	decomissionClusterCmd.Flags().StringVar(&provisionClusterType, "clusterType", "kubernetes", "Cluster type")

--- a/internal/app/cli/table.go
+++ b/internal/app/cli/table.go
@@ -957,7 +957,7 @@ func FromSuccess(result *grpc_common_go.Success) *ResultTable {
 
 func FromOpResponse(result *grpc_public_api_go.OpResponse) *ResultTable {
 	r := make([][]string, 0)
-	if result.Error != "" {
+	if result.Error == "" {
 		r = append(r, []string{"REQUEST_ID", "OPERATION", "TIMESTAMP", "ELAPSED", "STATUS", "INFO"})
 		r = append(r, []string{result.RequestId, result.OperationName,
 			time.Unix(result.Timestamp, 0).String(), time.Duration(result.ElapsedTime).String(),


### PR DESCRIPTION
#### What does this PR do?

* Improve cluster listing with the `--watch` option

#### Where should the reviewer start?

A simple function to compare which clusters are modified is used to avoid repeating clusters without changes. The changes are also computed on shown columns so that fields such as the last reported ping is not considered.

#### What is missing?

#### How should this be manually tested?

```
$ public-api-cli cluster list -w
NAME            ID                                     NODES   LABELS       STATE                 STATUS
dhigueroapp04   00630f9c-59fe-408a-829c-6dc67c2b98e7   0                    INSTALLED             OFFLINE_CORDON
dhiguero09      10f63fbe-8145-4390-bdf4-169ef689063b   0                    INSTALL_IN_PROGRESS   ONLINE
dhigueroapp05   38f707ae-7fea-453c-95f9-b7261d66c883   0                    INSTALLED             OFFLINE_CORDON
app2-nalej63    4926ac06-fa35-404c-b05a-38fa1c2e3b5e   0       test:false   INSTALLED             ONLINE
dhiguero07      5fd2578c-bb52-40f3-833c-c06395a16244   0                    INSTALL_IN_PROGRESS   ONLINE
dhiguero08      8ae32a29-d0d8-412e-b4ad-49a9ee342983   0                    FAILURE               UNKNOWN
app1-nalej63    916cd6b6-bb4d-4376-a428-8c311ede0959   0       test:true    INSTALLED             ONLINE
dhigueroapp03   b5794e4d-d00a-4b0d-91d0-bff6e5d090c2   0                    INSTALLED             UNKNOWN
dhiguero10      ea0a4caf-1963-4b09-8c4e-8af0344878ed   0                    INSTALL_IN_PROGRESS   ONLINE
dhiguero06      f821af02-3aeb-4312-b48b-2ecf1fcf9afc   0                    FAILURE               UNKNOWN
dhiguero11      fc3acd3f-732e-4a20-ae88-9763fdc85219   0                    UNINSTALLING          ONLINE_CORDON

NAME         ID                                     NODES   LABELS   STATE         STATUS
dhiguero11   fc3acd3f-732e-4a20-ae88-9763fdc85219   0                PROVISIONED   ONLINE_CORDON

NAME         ID                                     NODES   LABELS   STATE         STATUS
dhiguero11   fc3acd3f-732e-4a20-ae88-9763fdc85219   0                PROVISIONED   OFFLINE_CORDON
```

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2401](https://nalej.atlassian.net/browse/NP-2401)

#### Screenshots (if appropriate)

#### Questions
