### PR TITLE
NP-2388 Fix bug on grouping.

### DIFF
--- a/internal/app/cli/table.go
+++ b/internal/app/cli/table.go
@@ -968,19 +968,19 @@ func FromOrganizationApplicationStatsResponse(response *grpc_monitoring_go.Organ
 	})
 
 	r = append(r, []string{"APPLICATION", "SERVICE GROUP", "SERVICE", "CPU", "MEMORY", "STORAGE"})
-	applicationName := ""
-	serviceGroupName := ""
+	applicationId := ""
+	serviceGroupId := ""
 	for _, stat := range stats {
 		line := make([]string, 0, 6)
-		if applicationName != stat.GetAppInstanceName() {
-			applicationName = stat.GetAppInstanceName()
-			line = append(line, applicationName)
+		if applicationId != stat.GetAppInstanceId() {
+			applicationId = stat.GetAppInstanceId()
+			line = append(line, stat.GetAppInstanceName())
 		} else {
 			line = append(line, "")
 		}
-		if serviceGroupName != stat.GetServiceGroupInstanceName() {
-			serviceGroupName = stat.GetServiceGroupInstanceName()
-			line = append(line, serviceGroupName)
+		if serviceGroupId != stat.GetServiceGroupInstanceId() {
+			serviceGroupId = stat.GetServiceGroupInstanceId()
+			line = append(line, stat.GetServiceGroupInstanceName())
 		} else {
 			line = append(line, "")
 		}


### PR DESCRIPTION
#### What does this PR do?
Fix a bug that was removing names on the table when the group names or application instance names were equal even when the IDs were different.

#### What are the relevant tickets?

- [NP-2388](https://nalej.atlassian.net/browse/NP-2388)

#### Screenshots (if appropriate)
```shell script
TIMESTAMP: 1576058131
APPLICATION    SERVICE GROUP   SERVICE     CPU           MEMORY          STORAGE
stress2        stress-group    stress      1.838454 mc   13.316589 MiB   4.598514 kiB
stress3                        stress      1.891393 mc   7.947915 MiB    3.168723 kiB
```
VS
```shell script
TIMESTAMP: 1576058331
APPLICATION    SERVICE GROUP   SERVICE     CPU           MEMORY          STORAGE
stress2        stress-group    stress      1.839833 mc   14.313382 MiB   4.585135 kiB
stress3        stress-group    stress      1.042093 mc   7.015415 MiB    3.115786 kiB
```