### PR TITLE
NP-2508 List Download Responses added

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -251,12 +251,12 @@
   version = "v0.0.57"
 
 [[projects]]
-  digest = "1:5aa788d8961cf7d63d9a3f7bda416aa374f06c2a46fad2a0a7d5c530cbcc0065"
+  digest = "1:6d73d2765df384574a8b2533ecc87716abd7bad857cf171c2ae6ec6f4fc0b984"
   name = "github.com/nalej/grpc-log-download-manager-go"
   packages = ["."]
   pruneopts = ""
-  revision = "2b1e9843b549229e7184223a7a7b080d751cfde3"
-  version = "v0.0.1"
+  revision = "309d10e59a5d5746a6626f0d6614d73233cc33f8"
+  version = "v0.0.2"
 
 [[projects]]
   digest = "1:47c7ff107cac9e04917b46348f45c7a9a0a0a2021a45f3ed0b20074d75ea043e"
@@ -307,12 +307,12 @@
   version = "v0.0.10"
 
 [[projects]]
-  digest = "1:386e9f37949537aa46076dccc21dea835940e31b6f08468c085b6cea01a5e2bb"
+  digest = "1:5e56f05e559c416ee72da6c4233da1eee1bad127ac9a7e1b2ad0a2ac050fb40b"
   name = "github.com/nalej/grpc-public-api-go"
   packages = ["."]
   pruneopts = ""
-  revision = "7858e2372239f8f8f95aa1519a520308ed9d47bb"
-  version = "v0.0.130"
+  revision = "098589d88e465924cf0237e5a324a4218dd9e338"
+  version = "v0.0.131"
 
 [[projects]]
   digest = "1:18d316170b65da520a335ae2e11818ed9a481cb57d8fb6c72ee2dc437bb148c4"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -65,7 +65,7 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-public-api-go"
-    version="=v0.0.130"
+    version="=v0.0.131"
 
 [[constraint]]
     name="github.com/nalej/grpc-login-api-go"
@@ -77,7 +77,7 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-log-download-manager-go"
-    version="=v0.0.1"
+    version="=v0.0.2"
 
 [[constraint]]
     name="github.com/nalej/authx"

--- a/cmd/public-api-cli/commands/unified-logging.go
+++ b/cmd/public-api-cli/commands/unified-logging.go
@@ -73,6 +73,8 @@ func init() {
 	downloadCmd.AddCommand(checkCmd)
 	checkCmd.Flags().StringVar(&requestId, "requestID", "", "request identifier")
 
+	downloadCmd.AddCommand(listCmd)
+
 }
 
 var searchCmd = &cobra.Command{
@@ -177,6 +179,24 @@ var checkCmd = &cobra.Command{
 			cliOptions.Resolve("cacert", caCertPath), cliOptions.Resolve("output", output), cliOptions.ResolveAsInt("labelLength", labelLength))
 
 		l.Check(cliOptions.Resolve("organizationID", organizationID), requestId)
+
+	},
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the status of all download requests",
+	Long:  `Check the status of all download requests`,
+	Run: func(cmd *cobra.Command, args []string) {
+		SetupLogging()
+
+		l := cli.NewUnifiedLogging(
+			cliOptions.Resolve("nalejAddress", nalejAddress),
+			cliOptions.ResolveAsInt("port", nalejPort),
+			insecure, useTLS,
+			cliOptions.Resolve("cacert", caCertPath), cliOptions.Resolve("output", output), cliOptions.ResolveAsInt("labelLength", labelLength))
+
+		l.List(cliOptions.Resolve("organizationID", organizationID))
 
 	},
 }

--- a/components/public-api/mngtcluster/public-api.configmap.yaml
+++ b/components/public-api/mngtcluster/public-api.configmap.yaml
@@ -55,6 +55,7 @@ data:
        "/public_api.UnifiedLogging/Search":{"should":["ORG", "APPS"]},
        "/public_api.UnifiedLogging/DownloadLog":{"should":["ORG", "APPS"]},
        "/public_api.UnifiedLogging/Check":{"should":["ORG", "APPS"]},
+       "/public_api.UnifiedLogging/List":{"should":["ORG", "APPS"]},
        "/public_api.Devices/AddDeviceGroup":{"should":["ORG", "DEVMNGR"]},
        "/public_api.Devices/UpdateDeviceGroup":{"should":["ORG", "DEVMNGR"]},
        "/public_api.Devices/RemoveDeviceGroup":{"should":["ORG", "DEVMNGR"]},

--- a/internal/app/cli/table.go
+++ b/internal/app/cli/table.go
@@ -107,6 +107,8 @@ func AsTable(result interface{}, labelLength int) *ResultTable {
 		return FromLogResponse(result)
 	case *grpc_public_api_go.DownloadLogResponse:
 		return FromDownloadLogResponse(result)
+	case *grpc_public_api_go.DownloadLogResponseList:
+		return FromDownloadLogResponseList(result)
 	case *grpc_public_api_go.Node:
 		return FromNode(result, labelLength)
 	case *grpc_public_api_go.NodeList:
@@ -547,6 +549,18 @@ func FromDownloadLogResponse(result *grpc_public_api_go.DownloadLogResponse) *Re
 		r = append(r, []string{""})
 		r = append(r, []string{"URL", "EXPIRATION"})
 		r = append(r, []string{result.Url, time.Unix(0, result.Expiration).String()})
+	}
+
+	return &ResultTable{r}
+}
+
+func FromDownloadLogResponseList(result *grpc_public_api_go.DownloadLogResponseList) *ResultTable {
+
+	r := make([][]string, 0)
+
+	r = append(r, []string{"REQUEST_ID", "STATE", "INFO"})
+	for _, response := range result.Responses {
+		r = append(r, []string{response.RequestId, response.StateName, response.Info})
 	}
 
 	return &ResultTable{r}

--- a/internal/pkg/server/unified-logging/handler.go
+++ b/internal/pkg/server/unified-logging/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nalej/derrors"
 	"github.com/nalej/grpc-application-manager-go"
 	"github.com/nalej/grpc-log-download-manager-go"
+	"github.com/nalej/grpc-organization-go"
 	"github.com/nalej/grpc-public-api-go"
 	"github.com/nalej/grpc-utils/pkg/conversions"
 	"github.com/nalej/public-api/internal/pkg/authhelper"
@@ -83,4 +84,19 @@ func (h *Handler) DownloadLog(ctx context.Context, request *grpc_log_download_ma
 		return nil, conversions.ToGRPCError(err)
 	}
 	return h.Manager.DownloadLog(request)
+}
+
+func (h *Handler) List(ctx context.Context, request *grpc_organization_go.OrganizationId) (*grpc_public_api_go.DownloadLogResponseList, error){
+	rm, err := authhelper.GetRequestMetadata(ctx)
+	if err != nil {
+		return nil, conversions.ToGRPCError(err)
+	}
+	if request.OrganizationId != rm.OrganizationID {
+		return nil, derrors.NewPermissionDeniedError("cannot access requested OrganizationID")
+	}
+	err = entities.ValidOrganizationId(request)
+	if err != nil {
+		return nil, conversions.ToGRPCError(err)
+	}
+	return h.Manager.List(request)
 }

--- a/internal/pkg/server/unified-logging/manager.go
+++ b/internal/pkg/server/unified-logging/manager.go
@@ -19,6 +19,7 @@ package unified_logging
 import (
 	"github.com/nalej/grpc-application-manager-go"
 	"github.com/nalej/grpc-log-download-manager-go"
+	"github.com/nalej/grpc-organization-go"
 	"github.com/nalej/grpc-public-api-go"
 	"github.com/nalej/grpc-utils/pkg/conversions"
 	"github.com/nalej/public-api/internal/pkg/entities"
@@ -83,4 +84,21 @@ func (m *Manager) DownloadLog(request *grpc_log_download_manager_go.DownloadLogR
 		return nil, err
 	}
 	return entities.ToPublicAPIDownloadLogReponse(response), nil
+}
+
+func (m *Manager) List(request *grpc_organization_go.OrganizationId) (*grpc_public_api_go.DownloadLogResponseList, error) {
+	ctx, cancel := common.GetContext()
+	defer cancel()
+	responses, err := m.logDownloadClient.List(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	responseList := make([]*grpc_public_api_go.DownloadLogResponse, len(responses.Responses))
+	for i, resp := range responses.Responses {
+		responseList[i] = entities.ToPublicAPIDownloadLogReponse(resp)
+	}
+	return &grpc_public_api_go.DownloadLogResponseList{
+		Responses: responseList,
+	}, nil
 }


### PR DESCRIPTION
#### What does this PR do?

1. Implement `List` to retrieve a list of DownloadResponses
````
Download application logs based on application and service group instance

Usage:
  public-api-cli log download [flags]
  public-api-cli log download [command]

Available Commands:
  check       Check the status of a download request
  get         Get results file
  list        List the status of all download requests
  search      Search and download log entries

Flags:
  -h, --help   help for download

Global Flags:
      --cacert string           Path of the CA certificate to validate the server connection
      --consoleLogging          Pretty print logging
      --debug                   Set debug level
      --insecure                Skip CA validation when connecting to a secure TLS server
      --nalejAddress string     Address (host) of the Nalej platform
      --organizationID string   Organization identifier
      --useTLS                  Connect to a TLS server (default true)

Use "public-api-cli log download [command] --help" for more information about a command.
````

2. Fix a bug when getting log responses file returns an error

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?
````
./public-api-cli log download list

REQUEST_ID                             STATE        INFO
fec9bc2f-a5b1-47da-838a-ad7294fc820a   DOWNLOADED   admin@nalej.com
ffcc59a2-65de-4eb5-94b7-4af3f6ac118e   DOWNLOADED   admin@nalej.com
7364ced1-f336-4bbf-a93d-86b6bd9553c6   READY        file generated
d6037353-2410-4e83-a1d5-d8cb09e09e9e   READY        file generated
```
#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2508](https://nalej.atlassian.net/browse/NP-2508)

#### Screenshots (if appropriate)

#### Questions
