### PR TITLE
NP-XX unified-logging address removed

### DIFF
--- a/cmd/public-api/commands/run.go
+++ b/cmd/public-api/commands/run.go
@@ -53,8 +53,6 @@ func init() {
 	runCmd.PersistentFlags().StringVar(&config.AuthConfigPath, "authConfigPath", "", "Authorization config path")
 	runCmd.PersistentFlags().StringVar(&config.DeviceManagerAddress, "deviceManagerAddress", "localhost:6010",
 		"Device Manager address (host:port)")
-	runCmd.PersistentFlags().StringVar(&config.UnifiedLoggingAddress, "unifiedLoggingAddress", "localhost:8323",
-		"Unified Logging Coordinator address (host:port)")
 	runCmd.PersistentFlags().StringVar(&config.MonitoringManagerAddress, "monitoringManagerAddress", "localhost:8423",
 		"Monitoring Manager address (host:port)")
 	runCmd.PersistentFlags().StringVar(&config.ProvisionerManagerAddress, "provisionerManagerAddress", "localhost:8930",

--- a/components/public-api/mngtcluster/public-api.deployment.yaml
+++ b/components/public-api/mngtcluster/public-api.deployment.yaml
@@ -48,7 +48,6 @@ spec:
         - "--applicationsManagerAddress=application-manager.__NPH_NAMESPACE:8910"
         - "--userManagerAddress=user-manager.__NPH_NAMESPACE:8920"
         - "--deviceManagerAddress=device-manager.__NPH_NAMESPACE:6010"
-        - "--unifiedLoggingAddress=unified-logging-coord.__NPH_NAMESPACE:8323"
         - "--monitoringManagerAddress=monitoring-manager.__NPH_NAMESPACE:8423"
         - "--inventoryManagerAddress=inventory-manager.__NPH_NAMESPACE:5510"
         - "--provisionerManagerAddress=provisioner.__NPH_NAMESPACE:8930"

--- a/internal/pkg/server/config.go
+++ b/internal/pkg/server/config.go
@@ -41,8 +41,6 @@ type Config struct {
 	UserManagerAddress string
 	// DeviceManagerAddress with the host:port to connect to the Device Manager component.
 	DeviceManagerAddress string
-	// UnifiedLoggingAddress with the host:port to connect to the Unified Logging Coordinator component.
-	UnifiedLoggingAddress string
 	// MonitoringManagerAddress with the host:port to connect to the Monitoring Manager component.
 	MonitoringManagerAddress string
 	// InventoryManagerAddress with the host:port to connect to the Inventory Manager component.
@@ -85,10 +83,6 @@ func (conf *Config) Validate() derrors.Error {
 
 	if conf.DeviceManagerAddress == "" {
 		return derrors.NewInvalidArgumentError("deviceManagerAddress must be set")
-	}
-
-	if conf.UnifiedLoggingAddress == "" {
-		return derrors.NewInvalidArgumentError("unifiedLoggingAddress must be set")
 	}
 
 	if conf.MonitoringManagerAddress == "" {
@@ -135,7 +129,6 @@ func (conf *Config) Print() {
 	log.Info().Str("URL", conf.InfrastructureManagerAddress).Msg("Infrastructure Manager")
 	log.Info().Str("URL", conf.ApplicationsManagerAddress).Msg("Applications Manager")
 	log.Info().Str("URL", conf.UserManagerAddress).Msg("User Manager")
-	log.Info().Str("URL", conf.UnifiedLoggingAddress).Msg("Unified Logging Coordinator Service")
 	log.Info().Str("URL", conf.MonitoringManagerAddress).Msg("Monitoring Manager Service")
 	log.Info().Str("URL", conf.DeviceManagerAddress).Msg("Device Manager Service")
 	log.Info().Str("URL", conf.InventoryManagerAddress).Msg("Inventory Manager Service")

--- a/internal/pkg/server/service.go
+++ b/internal/pkg/server/service.go
@@ -32,7 +32,6 @@ import (
 	"github.com/nalej/grpc-organization-manager-go"
 	"github.com/nalej/grpc-provisioner-go"
 	"github.com/nalej/grpc-public-api-go"
-	"github.com/nalej/grpc-unified-logging-go"
 	"github.com/nalej/grpc-user-manager-go"
 	"github.com/nalej/public-api/internal/pkg/server/agent"
 	"github.com/nalej/public-api/internal/pkg/server/application-network"
@@ -78,7 +77,6 @@ type Clients struct {
 	umClient          grpc_user_manager_go.UserManagerClient
 	appClient         grpc_application_manager_go.ApplicationManagerClient
 	deviceClient      grpc_device_manager_go.DevicesClient
-	ulClient          grpc_unified_logging_go.CoordinatorClient
 	unifLoggClient    grpc_application_manager_go.UnifiedLoggingClient
 	mmClient          grpc_monitoring_go.MonitoringManagerClient
 	amClient          grpc_monitoring_go.AssetMonitoringClient
@@ -111,10 +109,6 @@ func (s *Service) GetClients() (*Clients, derrors.Error) {
 	if err != nil {
 		return nil, derrors.AsError(err, "cannot create connection with the device manager")
 	}
-	ulConn, err := grpc.Dial(s.Configuration.UnifiedLoggingAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, derrors.AsError(err, "cannot create connection with unified logging coordinator")
-	}
 	mmConn, err := grpc.Dial(s.Configuration.MonitoringManagerAddress, grpc.WithInsecure())
 	if err != nil {
 		return nil, derrors.AsError(err, "cannot create connection with infrastructure monitor coordinator")
@@ -143,7 +137,7 @@ func (s *Service) GetClients() (*Clients, derrors.Error) {
 	umClient := grpc_user_manager_go.NewUserManagerClient(umConn)
 	appClient := grpc_application_manager_go.NewApplicationManagerClient(appConn)
 	deviceClient := grpc_device_manager_go.NewDevicesClient(devConn)
-	ulClient := grpc_unified_logging_go.NewCoordinatorClient(ulConn)
+	//ulClient := grpc_unified_logging_go.NewCoordinatorClient(ulConn)
 	mmClient := grpc_monitoring_go.NewMonitoringManagerClient(mmConn)
 	amClient := grpc_monitoring_go.NewAssetMonitoringClient(mmConn)
 	eicClient := grpc_inventory_manager_go.NewEICClient(invManagerConn)
@@ -155,7 +149,7 @@ func (s *Service) GetClients() (*Clients, derrors.Error) {
 	downloadClient := grpc_log_download_manager_go.NewLogDownloadManagerClient(logDownConn)
 
 	return &Clients{oClient, cClient, nClient, infraClient, umClient,
-		appClient, deviceClient, ulClient, unifLoggClient, mmClient, amClient,
+		appClient, deviceClient,unifLoggClient, mmClient, amClient,
 		eicClient, invClient, agentClient, appNetClient,
 		provClient, downloadClient}, nil
 }


### PR DESCRIPTION
#### What does this PR do?
UnifiedLoggingAddress removed. 
Public-api does not connect to unified-logging. The orders are sent through application-manager or log-download-manager
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-XXX](https://nalej.atlassian.net/browse/NP-XXX)

#### Screenshots (if appropriate)

#### Questions
