### PR TITLE
NP-2549 --clusterID removed from info command

### DIFF
--- a/cmd/public-api-cli/commands/clusters.go
+++ b/cmd/public-api-cli/commands/clusters.go
@@ -66,7 +66,6 @@ func init() {
 	clustersCmd.AddCommand(clusterLabelsCmd)
 
 	clustersCmd.AddCommand(infoClusterCmd)
-	infoClusterCmd.Flags().StringVar(&clusterID, "clusterID", "", "Cluster identifier")
 
 	clustersCmd.AddCommand(cordonClusterCmd)
 	clustersCmd.AddCommand(uncordonClusterCmd)
@@ -132,7 +131,7 @@ var infoClusterCmd = &cobra.Command{
 	Aliases: []string{"get"},
 	Short:   "Get the cluster information",
 	Long:    `Get the cluster information`,
-	Args:    cobra.MaximumNArgs(1),
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		SetupLogging()
 		c := cli.NewClusters(


### PR DESCRIPTION
#### What does this PR do?
removes `clusterID` flag from the `cluster info` command.

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?
executing the command
`public-api-cli cluster info <clusterID> [flags]`
#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2549](https://nalej.atlassian.net/browse/NP-2549)

#### Screenshots (if appropriate)

#### Questions
