### PR TITLE
NP-2564 Order options when listing clusters added

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -315,12 +315,12 @@
   version = "v0.0.11"
 
 [[projects]]
-  digest = "1:0d47406622fc27a43b0a52a2410e2ab5dd298b2a750edd69c79a5ca687743fe2"
+  digest = "1:0b45fb4691f4083b05434ecc5a6c8aa7614c6fa9952787437ecaa4408275bcc3"
   name = "github.com/nalej/grpc-public-api-go"
   packages = ["."]
   pruneopts = ""
-  revision = "b091b931a4286a6feabe321cbb3b48c9813c0a15"
-  version = "v0.0.139"
+  revision = "cbee7254ab7a36102791264aad7db40161d302b7"
+  version = "v0.0.141"
 
 [[projects]]
   digest = "1:9996325ca6794ee35aea9478f041ef73eaf4e4a4f8418943e6c9aec1a9f5a211"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -68,7 +68,7 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-public-api-go"
-    version="=v0.0.139"
+    version="=v0.0.141"
 
 [[constraint]]
     name="github.com/nalej/grpc-login-api-go"

--- a/cmd/public-api-cli/commands/clusters.go
+++ b/cmd/public-api-cli/commands/clusters.go
@@ -53,6 +53,8 @@ func init() {
 	clustersCmd.AddCommand(installClustersCmd)
 
 	listClustersCmd.Flags().BoolVarP(&watch, "watch", "w", false, "Watch for changes")
+	listClustersCmd.Flags().StringVar(&orderBy, "orderBy", "name", "field by which the clusters will be sorted (name, status or state)")
+	listClustersCmd.Flags().BoolVar(&desc, "desc", false, "Sort clusters in descending order")
 	clustersCmd.AddCommand(listClustersCmd)
 
 	updateClusterCmd.Flags().Float64Var(&millicoresConversionFactor, "millicoresConversionFactor", math.NaN(), "Modify the millicoresConversionFactor assigned to the cluster")
@@ -155,7 +157,7 @@ var listClustersCmd = &cobra.Command{
 			cliOptions.ResolveAsInt("port", nalejPort),
 			insecure, useTLS,
 			cliOptions.Resolve("cacert", caCertPath), cliOptions.Resolve("output", output), cliOptions.ResolveAsInt("labelLength", labelLength))
-		c.List(cliOptions.Resolve("organizationID", organizationID), watch)
+		c.List(cliOptions.Resolve("organizationID", organizationID), watch, orderBy, desc)
 	},
 }
 

--- a/cmd/public-api-cli/commands/variables.go
+++ b/cmd/public-api-cli/commands/variables.go
@@ -95,6 +95,7 @@ var watch bool
 
 // cluster update
 var millicoresConversionFactor float64
+var orderBy string
 
 var outputPath string
 var edgeControllerID string

--- a/internal/pkg/server/clusters/handler.go
+++ b/internal/pkg/server/clusters/handler.go
@@ -22,7 +22,6 @@ import (
 	"github.com/nalej/grpc-common-go"
 	"github.com/nalej/grpc-infrastructure-go"
 	"github.com/nalej/grpc-infrastructure-manager-go"
-	"github.com/nalej/grpc-organization-go"
 	"github.com/nalej/grpc-provisioner-go"
 	"github.com/nalej/grpc-public-api-go"
 	"github.com/nalej/grpc-utils/pkg/conversions"
@@ -156,19 +155,19 @@ func (h *Handler) Info(ctx context.Context, clusterID *grpc_infrastructure_go.Cl
 }
 
 // List all the clusters in an organization.
-func (h *Handler) List(ctx context.Context, organizationID *grpc_organization_go.OrganizationId) (*grpc_public_api_go.ClusterList, error) {
+func (h *Handler) List(ctx context.Context, request *grpc_public_api_go.ListRequest) (*grpc_public_api_go.ClusterList, error) {
 	rm, err := authhelper.GetRequestMetadata(ctx)
 	if err != nil {
 		return nil, conversions.ToGRPCError(err)
 	}
-	if organizationID.OrganizationId != rm.OrganizationID {
+	if request.OrganizationId != rm.OrganizationID {
 		return nil, derrors.NewPermissionDeniedError("cannot access requested OrganizationID")
 	}
-	err = entities.ValidOrganizationId(organizationID)
+	err = entities.ValidListRequest(request)
 	if err != nil {
 		return nil, conversions.ToGRPCError(err)
 	}
-	return h.Manager.List(organizationID)
+	return h.Manager.List(request)
 }
 
 // Update the cluster information.

--- a/internal/pkg/server/clusters/handler_it_test.go
+++ b/internal/pkg/server/clusters/handler_it_test.go
@@ -28,9 +28,9 @@ import (
 	"fmt"
 	"github.com/nalej/authx/pkg/interceptor"
 	"github.com/nalej/grpc-authx-go"
+	grpc_common_go "github.com/nalej/grpc-common-go"
 	"github.com/nalej/grpc-infrastructure-go"
 	"github.com/nalej/grpc-infrastructure-manager-go"
-	"github.com/nalej/grpc-organization-go"
 	"github.com/nalej/grpc-organization-manager-go"
 	"github.com/nalej/grpc-public-api-go"
 	"github.com/nalej/grpc-utils/pkg/test"
@@ -159,10 +159,14 @@ var _ = ginkgo.Describe("Clusters", func() {
 		}
 	})
 
-	ginkgo.It("should be able to list the clusters", func() {
+	ginkgo.FIt("should be able to list the clusters", func() {
 
-		organizationID := &grpc_organization_go.OrganizationId{
+		organizationID := &grpc_public_api_go.ListRequest{
 			OrganizationId: targetOrganization.OrganizationId,
+			Order: &grpc_common_go.OrderOptions{
+				Field:                "name",
+				Order:                grpc_common_go.Order_ASC,
+			},
 		}
 
 		tests := make([]utils.TestResult, 0)
@@ -173,7 +177,7 @@ var _ = ginkgo.Describe("Clusters", func() {
 		for _, test := range tests {
 			ctx, cancel := ithelpers.GetContext(test.Token)
 			defer cancel()
-			clusters, err := client.List(ctx, organizationID)
+			clusters, err := client.List(ctx,  organizationID)
 			if test.Success {
 				gomega.Expect(err).To(gomega.Succeed())
 				gomega.Expect(len(clusters.Clusters)).To(gomega.Equal(1))

--- a/internal/pkg/server/decorators/sorting_decorator.go
+++ b/internal/pkg/server/decorators/sorting_decorator.go
@@ -20,7 +20,9 @@ import (
 	"github.com/nalej/derrors"
 	"github.com/nalej/grpc-application-go"
 	"github.com/nalej/grpc-application-manager-go"
+	grpc_common_go "github.com/nalej/grpc-common-go"
 	"github.com/nalej/grpc-organization-manager-go"
+	grpc_public_api_go "github.com/nalej/grpc-public-api-go"
 	"github.com/nalej/public-api/internal/pkg/utils"
 	"github.com/rs/zerolog/log"
 	"reflect"
@@ -32,6 +34,7 @@ import (
 var AppDescriptorListAllowedFields = []string{"name"}
 var LogResponseAllowedFields = []string{"timestamp"}
 var SettingsAllowedFields = []string{"key"}
+var ClusterListAllowedFields = []string{"name", "status_name", "state_name"}
 
 // OrderOptions represents the ordering to be applied
 type OrderOptions struct {
@@ -39,6 +42,10 @@ type OrderOptions struct {
 	Field string
 	// ascending or descending order
 	Asc bool
+}
+
+func NewOrderOptions (order grpc_common_go.OrderOptions) OrderOptions {
+	return OrderOptions{Field: order.Field, Asc: order.Order == grpc_common_go.Order_ASC}
 }
 
 // OrderDecorator implements Decorator interface
@@ -61,6 +68,8 @@ func (od *OrderDecorator) Validate(result interface{}) derrors.Error {
 		return od.ValidateSortingDecorator(LogResponseAllowedFields)
 	case []*grpc_organization_manager_go.Setting:
 		return od.ValidateSortingDecorator(SettingsAllowedFields)
+	case []*grpc_public_api_go.Cluster:
+		return od.ValidateSortingDecorator(ClusterListAllowedFields)
 	}
 
 	return derrors.NewInvalidArgumentError("sorting decorator not allowed")

--- a/internal/pkg/server/organization-settings/manager.go
+++ b/internal/pkg/server/organization-settings/manager.go
@@ -59,7 +59,7 @@ func (m *Manager) List(organizationID *grpc_public_api_go.ListRequest) (*grpc_or
 	}
 	// if sorting requested -> apply the decorator
 	if organizationID.Order != nil {
-		sortOptions := decorators.OrderOptions{Field: organizationID.Order.Field, Asc: organizationID.Order.Order == grpc_common_go.Order_ASC}
+		sortOptions := decorators.NewOrderOptions(*organizationID.Order)
 		sortingResponse := decorators.ApplyDecorator(list.Settings, decorators.NewOrderDecorator(sortOptions))
 		if sortingResponse.Error != nil {
 			return nil, conversions.ToGRPCError(sortingResponse.Error)


### PR DESCRIPTION
#### What does this PR do?
includes sort options when listing the clusters:
- updates Sortdecorator to include cluster list
- modifies the `public-api-cli` to add flags to allow listing the cluster ordered

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?
```
List clusters

Usage:
  public-api-cli cluster list [flags]

Aliases:
  list, ls

Flags:
      --desc             Sort clusters in descending order
  -h, --help             help for list
      --orderBy string   field by which the clusters will be sorted (name, status or state) (default "name")
  -w, --watch            Watch for changes

Global Flags:
      --cacert string         Path of the CA certificate to validate the server connection
      --consoleLogging        Pretty print logging
      --debug                 Set debug level
      --insecure              Skip CA validation when connecting to a secure TLS server
      --nalejAddress string   Address (host) of the Nalej platform
      --useTLS                Connect to a TLS server (default true)

```
#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-XXX](https://nalej.atlassian.net/browse/NP-XXX)

#### Screenshots (if appropriate)

#### Questions
